### PR TITLE
Refactor to load environment only when necessary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7262,6 +7262,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "core-js": "^3.4.4",
     "vue": "^2.6.10",
     "vuetify": "^2.1.0",
-    "vuex": "^3.1.2"
+    "vuex": "^3.1.2",
+    "moment": "^2.15.2"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.1.0",

--- a/src/GitLabEnvironments.vue
+++ b/src/GitLabEnvironments.vue
@@ -21,16 +21,7 @@
           >
             <template v-slot:body="{ items }">
               <tbody>
-              <tr v-for="item in items" :key="item.name">
-                <td>{{ item.name }}</td>
-                <td>{{ environmentBranch(item) }}</td>
-                <td>
-                  <EnvironmentStatus :value="environmentStatus(item)"/>
-                </td>
-                <td>
-                  <EnvironmentDeployment :triggererIcon="deploymentTrigger(item)" :deployedAt="deploymentFinishedAt(item)"/>
-                </td>
-              </tr>
+              <Environment v-for="item in items" :key="item.name" :environment="item"/>
               </tbody>
             </template>
           </v-data-table>
@@ -44,12 +35,11 @@
 </template>
 
 <script>
-import EnvironmentStatus from "./components/EnvironmentStatus";
-import EnvironmentDeployment from "./components/EnvironmentDeployment";
+import Environment from "./components/Environment";
 
   export default {
     name      : "GitLabEnvironments",
-    components: {EnvironmentDeployment, EnvironmentStatus},
+    components: {Environment},
     data() {
       return {
         overlay() {
@@ -70,26 +60,6 @@ import EnvironmentDeployment from "./components/EnvironmentDeployment";
         environments() {
           return this.$store.state.environments
         },
-        environmentBranch(environment) {
-          let lastDeployment = environment.last_deployment
-
-          return lastDeployment ? lastDeployment.ref : 'NA'
-        },
-        environmentStatus(environment) {
-          let lastDeployment = environment.last_deployment
-
-          return lastDeployment ? lastDeployment.deployable.status : 'NA'
-        },
-        deploymentTrigger(environment) {
-          let lastDeployment = environment.last_deployment
-
-          return lastDeployment ? lastDeployment.user.avatar_url : ''
-        },
-        deploymentFinishedAt(environment) {
-          let lastDeployment = environment.last_deployment
-
-          return lastDeployment ? lastDeployment.deployable.finished_at : 'NA'
-        }
       }
     },
     created() {

--- a/src/GitLabEnvironments.vue
+++ b/src/GitLabEnvironments.vue
@@ -18,6 +18,7 @@
                   :headers="headers"
                   :items=environments()
                   :search="search"
+                  :loading="isLoading"
           >
             <template v-slot:body="{ items }">
               <tbody>
@@ -28,9 +29,6 @@
         </v-card>
       </v-container>
     </v-content>
-    <v-overlay :value=overlay()>
-      <v-progress-circular indeterminate size="64"/>
-    </v-overlay>
   </v-app>
 </template>
 
@@ -60,6 +58,11 @@ import Environment from "./components/Environment";
         environments() {
           return this.$store.state.environments
         },
+      }
+    },
+    computed : {
+      isLoading() {
+        return this.$store.state.isLoading;
       }
     },
     created() {

--- a/src/components/Environment.vue
+++ b/src/components/Environment.vue
@@ -1,0 +1,53 @@
+<template>
+    <tr>
+        <td>{{ environment.name }}</td>
+        <td><EnvironmentBranch :branch="environmentBranch(environment)"/></td>
+        <td><EnvironmentStatus :status="environmentStatus(environment)"/></td>
+        <td><EnvironmentDeployment :triggererIcon="deploymentTrigger(environment)" :deployedAt="deploymentFinishedAt(environment)"/></td>
+    </tr>
+</template>
+
+<script>
+  import EnvironmentBranch from "./EnvironmentBranch";
+  import EnvironmentStatus from "./EnvironmentStatus";
+  import EnvironmentDeployment from "./EnvironmentDeployment";
+
+  export default {
+    name      : "Environment",
+    components: {EnvironmentDeployment, EnvironmentStatus, EnvironmentBranch},
+    props     : {
+      environment: {
+        type    : Object,
+        required: true,
+      }
+    },
+    data() {
+      return {
+        environmentBranch(environment) {
+          let lastDeployment = environment.last_deployment;
+
+          return lastDeployment ? lastDeployment.ref : ''
+        },
+        environmentStatus(environment) {
+          let lastDeployment = environment.last_deployment;
+
+          return lastDeployment ? lastDeployment.deployable.status : ''
+        },
+        deploymentTrigger(environment) {
+          let lastDeployment = environment.last_deployment;
+
+          return lastDeployment ? lastDeployment.user.avatar_url : ''
+        },
+        deploymentFinishedAt(environment) {
+          let lastDeployment = environment.last_deployment;
+
+          return lastDeployment ? lastDeployment.deployable.finished_at : 'NA'
+        }
+      }
+    }
+  }
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/Environment.vue
+++ b/src/components/Environment.vue
@@ -1,9 +1,22 @@
 <template>
     <tr>
-        <td>{{ environment.name }}</td>
-        <td><EnvironmentBranch :branch="environmentBranch(environment)"/></td>
-        <td><EnvironmentStatus :status="environmentStatus(environment)"/></td>
-        <td><EnvironmentDeployment :triggererIcon="deploymentTrigger(environment)" :deployedAt="deploymentFinishedAt(environment)"/></td>
+        <td>
+            <v-row>
+                <v-switch inset :disabled="disabled" @change="loadEnvironment" class="d-inline"/>
+                <p class="d-inline my-auto">{{ environment.name }}</p>
+            </v-row>
+        </td>
+        <td>
+            <EnvironmentBranch :branch="environmentBranch(environment)" :loading="loading"/>
+        </td>
+        <td>
+            <EnvironmentStatus :status="environmentStatus(environment)" :loading="loading"/>
+        </td>
+        <td>
+            <EnvironmentDeployment :loading="loading"
+                                   :triggererIcon="deploymentTrigger(environment)"
+                                   :deployedAt="deploymentFinishedAt(environment)"/>
+        </td>
     </tr>
 </template>
 
@@ -23,6 +36,8 @@
     },
     data() {
       return {
+        disabled: false,
+        loading : false,
         environmentBranch(environment) {
           let lastDeployment = environment.last_deployment;
 
@@ -43,6 +58,12 @@
 
           return lastDeployment ? lastDeployment.deployable.finished_at : 'NA'
         }
+      }
+    },
+    methods   : {
+      loadEnvironment() {
+        this.disabled = true;
+        this.loading = true;
       }
     }
   }

--- a/src/components/EnvironmentBranch.vue
+++ b/src/components/EnvironmentBranch.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <p v-if="branch" class="my-auto">{{ branch }}</p>
-        <v-skeleton-loader v-else ref="skeleton" type="text" :boilerplate="!loading"/>
+        <v-skeleton-loader v-else ref="skeleton" type="list-item" :boilerplate="!loading" style="background-color: transparent"/>
     </div>
 </template>
 
@@ -20,5 +20,7 @@
 </script>
 
 <style scoped>
-
+    .theme--light.v-skeleton-loader >>> .v-skeleton-loader__list-item {
+        background-color: transparent;
+    }
 </style>

--- a/src/components/EnvironmentBranch.vue
+++ b/src/components/EnvironmentBranch.vue
@@ -1,0 +1,26 @@
+<template>
+    <div>
+        <p v-if="branch">{{ branch }}</p>
+        <v-skeleton-loader v-else ref="skeleton" type="text" :boilerplate="boilerplate"/>
+    </div>
+</template>
+
+<script>
+  export default {
+    name: "EnvironmentBranch",
+    props: {
+      branch: {
+        type: String,
+      }
+    },
+    data() {
+      return {
+        boilerplate: true
+      }
+    }
+  }
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/EnvironmentBranch.vue
+++ b/src/components/EnvironmentBranch.vue
@@ -1,23 +1,21 @@
 <template>
     <div>
-        <p v-if="branch">{{ branch }}</p>
-        <v-skeleton-loader v-else ref="skeleton" type="text" :boilerplate="boilerplate"/>
+        <p v-if="branch" class="my-auto">{{ branch }}</p>
+        <v-skeleton-loader v-else ref="skeleton" type="text" :boilerplate="!loading"/>
     </div>
 </template>
 
 <script>
   export default {
-    name: "EnvironmentBranch",
+    name : "EnvironmentBranch",
     props: {
-      branch: {
+      branch : {
         type: String,
-      }
+      },
+      loading: {
+        type: Boolean,
+      },
     },
-    data() {
-      return {
-        boilerplate: true
-      }
-    }
   }
 </script>
 

--- a/src/components/EnvironmentDeployment.vue
+++ b/src/components/EnvironmentDeployment.vue
@@ -6,7 +6,7 @@
             </v-avatar>
             {{ readableDate(deployedAt) }}
         </div>
-        <v-skeleton-loader v-else ref="skeleton" type="avatar" :boilerplate="!loading"/>
+        <v-skeleton-loader v-else ref="skeleton" type="list-item-avatar" :boilerplate="!loading"/>
     </div>
 </template>
 
@@ -38,5 +38,7 @@
 </script>
 
 <style scoped>
-
+    .theme--light.v-skeleton-loader >>> .v-skeleton-loader__list-item-avatar {
+        background-color: transparent;
+    }
 </style>

--- a/src/components/EnvironmentDeployment.vue
+++ b/src/components/EnvironmentDeployment.vue
@@ -6,9 +6,7 @@
             </v-avatar>
             {{ readableDate(deployedAt) }}
         </div>
-        <v-avatar v-else color="grey" size="26">
-            <span class="white--text">NA</span>
-        </v-avatar>
+        <v-skeleton-loader v-else ref="skeleton" type="avatar" :boilerplate="boilerplate"/>
     </div>
 </template>
 
@@ -27,8 +25,9 @@
     },
     data() {
       return {
+        boilerplate: true,
         readableDate(date) {
-          date = new Date(date)
+          date = new Date(date);
           return date.toDateString()
         }
       }

--- a/src/components/EnvironmentDeployment.vue
+++ b/src/components/EnvironmentDeployment.vue
@@ -6,26 +6,28 @@
             </v-avatar>
             {{ readableDate(deployedAt) }}
         </div>
-        <v-skeleton-loader v-else ref="skeleton" type="avatar" :boilerplate="boilerplate"/>
+        <v-skeleton-loader v-else ref="skeleton" type="avatar" :boilerplate="!loading"/>
     </div>
 </template>
 
 <script>
   export default {
-    name: "EnvironmentDeployment",
+    name : "EnvironmentDeployment",
     props: {
-      deployedAt: {
-        type: String,
+      deployedAt   : {
+        type    : String,
         required: true,
       },
       triggererIcon: {
-        type: String,
+        type    : String,
         required: true,
-      }
+      },
+      loading      : {
+        type: Boolean,
+      },
     },
     data() {
       return {
-        boilerplate: true,
         readableDate(date) {
           date = new Date(date);
           return date.toDateString()

--- a/src/components/EnvironmentDeployment.vue
+++ b/src/components/EnvironmentDeployment.vue
@@ -11,6 +11,8 @@
 </template>
 
 <script>
+  import moment from 'moment';
+
   export default {
     name : "EnvironmentDeployment",
     props: {
@@ -29,8 +31,7 @@
     data() {
       return {
         readableDate(date) {
-          date = new Date(date);
-          return date.toDateString()
+          return moment(date).format('Do MMM Y @ HH:mm');
         }
       }
     }

--- a/src/components/EnvironmentStatus.vue
+++ b/src/components/EnvironmentStatus.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <v-chip v-if="status" key="environment-status" :color="color()" dark>{{ status }}</v-chip>
-        <v-skeleton-loader v-else ref="skeleton" type="chip" :boilerplate="boilerplate"/>
+        <v-skeleton-loader v-else ref="skeleton" type="chip" :boilerplate="!loading"/>
     </div>
 </template>
 
@@ -9,14 +9,16 @@
   export default {
     name : "EnvironmentStatus",
     props: {
-      status: {
+      status : {
         type    : String,
         required: true,
-      }
+      },
+      loading: {
+        type: Boolean,
+      },
     },
     data() {
       return {
-        boilerplate: true,
         color() {
           if (this.status === 'success') {
             return 'green'

--- a/src/components/EnvironmentStatus.vue
+++ b/src/components/EnvironmentStatus.vue
@@ -1,31 +1,33 @@
 <template>
-    <v-chip :color="getColor(value)" dark>{{ value }}</v-chip>
+    <div>
+        <v-chip v-if="status" key="environment-status" :color="color()" dark>{{ status }}</v-chip>
+        <v-skeleton-loader v-else ref="skeleton" type="chip" :boilerplate="boilerplate"/>
+    </div>
 </template>
 
 <script>
   export default {
     name : "EnvironmentStatus",
     props: {
-      value: {
+      status: {
         type    : String,
         required: true,
       }
     },
-    methods: {
-      getColor(value) {
-        if (value === 'success') {
-          return 'green'
-        }
-        if (value === 'failed') {
-          return 'red'
-        }
+    data() {
+      return {
+        boilerplate: true,
+        color() {
+          if (this.status === 'success') {
+            return 'green'
+          }
+          if (this.status === 'failed') {
+            return 'red'
+          }
 
-        return 'gray'
+          return 'gray'
+        }
       }
-    }
+    },
   }
 </script>
-
-<style scoped>
-
-</style>

--- a/src/store.js
+++ b/src/store.js
@@ -6,21 +6,12 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state    : {
-    environments: [],
-    totalEnvironments: 0,
-    isLoading: true,
+    environments     : [],
+    isLoading        : true,
   },
   mutations: {
-    CLEAR_ENVIRONMENTS(state) {
-      state.environments = []
-      state.totalEnvironments = 0
-    },
-    SET_TOTAL(state, value) {
-      state.totalEnvironments = value
-    },
-    ADD_ENVIRONMENT(state, environment) {
-      state.environments.push(environment)
-      state.isLoading = state.environments.length < state.totalEnvironments
+    SET_ENVIRONMENTS(state, environments) {
+      state.environments = environments;
     },
     SET_LOADING(state, isLoading) {
       state.isLoading = isLoading
@@ -28,22 +19,15 @@ export default new Vuex.Store({
   },
   actions  : {
     fetchEnvironments({commit}) {
-      commit("SET_LOADING", true)
-      commit("CLEAR_ENVIRONMENTS")
+      commit("SET_LOADING", true);
+      commit("SET_ENVIRONMENTS", []);
       return GitLabService.getEnvironments()
         .then(environments => {
           environments = environments.filter((environment) => {
             return environment.state === 'available'
-          })
-          commit("SET_TOTAL", environments.length)
-          environments.forEach(function (environment) {
-            GitLabService.getEnvironment(environment.id)
-              .then(response => {
-                let environment = response.data
-
-                commit("ADD_ENVIRONMENT", environment);
-              })
-        })
+          });
+          commit("SET_ENVIRONMENTS", environments);
+          commit("SET_LOADING", false);
           return this;
         })
         .catch(error => {
@@ -52,5 +36,18 @@ export default new Vuex.Store({
           commit("SET_LOADING", false)
         });
     },
+    fetchEnvironment({commit}, {environmentId}) {
+      commit("SET_LOADING", true);
+      return GitLabService.getEnvironment(environmentId)
+        .then(response => {
+          commit("SET_LOADING", false);
+          return response
+        })
+        .catch(error => {
+          // eslint-disable-next-line no-console
+          console.log('There was an error: ', error);
+          commit("SET_LOADING", false)
+        })
+    }
   }
 })


### PR DESCRIPTION
The original code was loading all environment on loading. But normally you are interested in one or two environments to no need to load all the others.
This PR changes the behaviour so that is the user that requests which environment to load, thus drastically reducing the number of API calls to GitLab.
As part of this PR I have also refactor the code to use more components for each environment.