### PR TITLE
Fix the date used to fetch an environment data

### DIFF
--- a/src/components/Environment.vue
+++ b/src/components/Environment.vue
@@ -24,6 +24,7 @@
 </template>
 
 <script>
+  import moment from 'moment';
   import EnvironmentBranch from "./EnvironmentBranch";
   import EnvironmentStatus from "./EnvironmentStatus";
   import EnvironmentDeployment from "./EnvironmentDeployment";
@@ -65,7 +66,9 @@
     },
     watch     : {
       date: function () {
-        this.loadEnvironmentFromDate(this.environment, this.date)
+          // eslint-disable-next-line no-console
+          console.log(this.date);
+        this.loadEnvironmentFromDate(this.environment, moment(this.date).add(1, 'day').toDate())
       }
     },
     methods   : {


### PR DESCRIPTION
We fetch the environment data up to a certain date. However this date is excluded, which means that if we choose today then today's deployment will not be returned. This is not what a user expects.

Closes #12 